### PR TITLE
feat: improve BCE 

### DIFF
--- a/dec.go
+++ b/dec.go
@@ -188,14 +188,15 @@ func (d *Decoder) more() (byte, error) {
 // next reads next non-whitespace token or error.
 func (d *Decoder) next() (byte, error) {
 	for {
-		for i := d.head; i < d.tail; i++ {
-			c := d.buf[i]
+		buf := d.buf[d.head:d.tail]
+		for i, c := range buf {
 			switch c {
 			case ' ', '\n', '\t', '\r':
 				continue
+			default:
+				d.head += i + 1
+				return c, nil
 			}
-			d.head = i + 1
-			return c, nil
 		}
 		if err := d.read(); err != nil {
 			return 0, err

--- a/dec_float.go
+++ b/dec_float.go
@@ -163,13 +163,14 @@ NonDecimalLoop:
 
 func (d *Decoder) number() []byte {
 	start := d.head
-	for i := d.head; i < d.tail; i++ {
-		switch c := d.buf[i]; c {
+	buf := d.buf[d.head:d.tail]
+	for i, c := range buf {
+		switch c {
 		case '+', '-', '.', 'e', 'E', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			continue
 		default:
 			// End of number.
-			d.head = i
+			d.head += i
 			return d.buf[start:d.head]
 		}
 	}

--- a/dec_int.go
+++ b/dec_int.go
@@ -149,10 +149,11 @@ func (d *Decoder) readUint32() (uint32, error) {
 		}
 	}
 	for {
-		for i := d.head; i < d.tail; i++ {
-			ind = intDigits[d.buf[i]]
+		buf := d.buf[d.head:d.tail]
+		for i, c := range buf {
+			ind = intDigits[c]
 			if ind == invalidCharForNumber {
-				d.head = i
+				d.head += i
 				return value, nil
 			}
 			if value > uint32SafeToMultiply10 {
@@ -275,10 +276,11 @@ func (d *Decoder) readUint64(c byte) (uint64, error) {
 		}
 	}
 	for {
-		for i := d.head; i < d.tail; i++ {
-			ind = intDigits[d.buf[i]]
+		buf := d.buf[d.head:d.tail]
+		for i, c := range buf {
+			ind = intDigits[c]
 			if ind == invalidCharForNumber {
-				d.head = i
+				d.head += i
 				return value, nil
 			}
 			if value > uint64SafeToMultiple10 {

--- a/dec_str.go
+++ b/dec_str.go
@@ -64,8 +64,8 @@ func (d *Decoder) str(v value) (value, error) {
 	if err := d.consume('"'); err != nil {
 		return value{}, errors.Wrap(err, "start")
 	}
-	for i := d.head; i < d.tail; i++ {
-		c := d.buf[i]
+	buf := d.buf[d.head:d.tail]
+	for i, c := range buf {
 		if c == '\\' {
 			// Character is escaped, fallback to slow path.
 			break
@@ -73,11 +73,11 @@ func (d *Decoder) str(v value) (value, error) {
 		if c == '"' {
 			// End of string in fast path.
 			if v.ignore {
-				d.head = i + 1
+				d.head += i + 1
 				return value{}, nil
 			}
-			str := d.buf[d.head:i]
-			d.head = i + 1
+			str := buf[:i]
+			d.head += i + 1
 			if v.raw {
 				return value{buf: str}, nil
 			}


### PR DESCRIPTION
Replace d.head..d.tail with range of sub-slice
to help compiler eliminate bound checks.

Benchstat results:
```
name                         old time/op    new time/op    delta
Decoder_Base64Append/128-4      507ns ± 2%     462ns ± 2%   -8.92%  (p=0.000 n=15+13)
Decoder_Base64Append/256-4      954ns ± 1%     865ns ± 1%   -9.32%  (p=0.000 n=13+13)
Decoder_Base64Append/512-4     1.86µs ± 1%    1.68µs ± 3%   -9.75%  (p=0.000 n=14+15)
Decoder_Base64Append/1024-4    3.67µs ± 1%    3.28µs ± 1%  -10.68%  (p=0.000 n=15+15)
OTEL_Decode-4                  1.55µs ± 2%    1.48µs ± 2%   -4.60%  (p=0.000 n=15+15)

name                         old speed      new speed      delta
Decoder_Base64Append/128-4    252MB/s ± 2%   277MB/s ± 2%   +9.79%  (p=0.000 n=15+13)
Decoder_Base64Append/256-4    268MB/s ± 1%   296MB/s ± 1%  +10.28%  (p=0.000 n=13+13)
Decoder_Base64Append/512-4    275MB/s ± 1%   305MB/s ± 3%  +10.82%  (p=0.000 n=14+15)
Decoder_Base64Append/1024-4   279MB/s ± 1%   312MB/s ± 1%  +11.95%  (p=0.000 n=15+15)
OTEL_Decode-4                 333MB/s ± 2%   350MB/s ± 2%   +4.83%  (p=0.000 n=15+15)
```