### PR TITLE
feat: inline reading to consume

### DIFF
--- a/dec.go
+++ b/dec.go
@@ -165,10 +165,21 @@ func (d *Decoder) Next() Type {
 	return types[v]
 }
 
-func (d *Decoder) consume(c byte) error {
-	got, err := d.more()
-	if err != nil {
-		return err
+var spaceSet = [256]byte{
+	' ': 1, '\n': 1, '\t': 1, '\r': 1,
+}
+
+func (d *Decoder) consume(c byte) (err error) {
+	buf := d.buf[d.head:d.tail]
+	var got byte
+	if len(buf) > 0 && spaceSet[buf[0]] == 0 {
+		d.head++
+		got = buf[0]
+	} else {
+		got, err = d.more()
+		if err != nil {
+			return err
+		}
 	}
 	if c != got {
 		return badToken(got)


### PR DESCRIPTION
```
name                        old time/op    new time/op    delta
Valid/canada.json-12          3.96ms ± 3%    3.88ms ± 1%   -1.99%  (p=0.017 n=10+9)
Valid/citm_catalog.json-12    1.99ms ± 2%    1.85ms ± 2%   -6.94%  (p=0.000 n=10+10)
Valid/floats.json-12          2.89µs ± 1%    2.84µs ± 1%   -1.54%  (p=0.000 n=10+9)
Valid/large.json-12           55.2µs ± 2%    49.6µs ± 3%  -10.10%  (p=0.000 n=10+10)
Valid/medium.json-12          3.72µs ± 1%    3.73µs ± 2%     ~     (p=0.838 n=10+10)
Valid/otel_ex_1.json-12        719ns ± 5%     619ns ± 1%  -13.91%  (p=0.000 n=10+10)
Valid/small.json-12            396ns ± 2%     346ns ± 3%  -12.48%  (p=0.000 n=10+10)
Valid/twitter.json-12         1.08ms ± 3%    1.06ms ± 2%   -1.75%  (p=0.017 n=10+9)

name                        old speed      new speed      delta
Valid/canada.json-12         569MB/s ± 3%   581MB/s ± 1%   +2.00%  (p=0.017 n=10+9)
Valid/citm_catalog.json-12   892MB/s ± 2%   959MB/s ± 2%   +7.46%  (p=0.000 n=10+10)
Valid/floats.json-12         807MB/s ± 1%   819MB/s ± 1%   +1.56%  (p=0.000 n=10+9)
Valid/large.json-12          509MB/s ± 2%   567MB/s ± 2%  +11.25%  (p=0.000 n=10+10)
Valid/medium.json-12         703MB/s ± 1%   702MB/s ± 2%     ~     (p=0.853 n=10+10)
Valid/otel_ex_1.json-12      722MB/s ± 6%   837MB/s ± 1%  +16.03%  (p=0.000 n=10+10)
Valid/small.json-12          508MB/s ± 2%   581MB/s ± 4%  +14.27%  (p=0.000 n=10+10)
Valid/twitter.json-12        597MB/s ± 3%   608MB/s ± 2%   +1.77%  (p=0.017 n=10+9)
```


