### PR TITLE
feat: smarter object and array skip

### DIFF
--- a/crawl_test.go
+++ b/crawl_test.go
@@ -1,0 +1,33 @@
+package jx
+
+import "github.com/go-faster/errors"
+
+func crawlValue(d *Decoder) error {
+	switch d.Next() {
+	case Null:
+		if err := d.Null(); err != nil {
+			return err
+		}
+	case Number:
+		if _, err := d.Float64(); err != nil {
+			return err
+		}
+	case Bool:
+		if _, err := d.Bool(); err != nil {
+			return err
+		}
+	case String:
+		if _, err := d.Str(); err != nil {
+			return err
+		}
+	case Array:
+		return d.Arr(crawlValue)
+	case Object:
+		return d.ObjBytes(func(d *Decoder, key []byte) error {
+			return crawlValue(d)
+		})
+	default:
+		return errors.New("invalid token")
+	}
+	return nil
+}

--- a/dec_arr.go
+++ b/dec_arr.go
@@ -33,15 +33,13 @@ func (d *Decoder) Elem() (ok bool, err error) {
 	}
 }
 
-func skipArr(d *Decoder) error { return d.Skip() }
-
 // Arr decodes array and invokes callback on each array element.
 func (d *Decoder) Arr(f func(d *Decoder) error) error {
-	if f == nil {
-		f = skipArr
-	}
 	if err := d.consume('['); err != nil {
 		return errors.Wrap(err, "start")
+	}
+	if f == nil {
+		return d.skipArr()
 	}
 	if err := d.incDepth(); err != nil {
 		return errors.Wrap(err, "inc")

--- a/dec_arr_test.go
+++ b/dec_arr_test.go
@@ -1,6 +1,7 @@
 package jx
 
 import (
+	"encoding/json"
 	"io"
 	"testing"
 
@@ -25,14 +26,14 @@ func TestDecoder_Arr(t *testing.T) {
 		require.ErrorIs(t, d.Arr(nil), io.ErrUnexpectedEOF)
 	})
 	t.Run("Invalid", func(t *testing.T) {
-		for _, s := range []string{
-			"[true,f",
-			"[true,false",
-			"[true,false,",
-			"[true,false}",
-		} {
+		for _, s := range testArrs {
+			checker := require.Error
+			if json.Valid([]byte(s)) {
+				checker = require.NoError
+			}
+
 			d := DecodeStr(s)
-			require.Error(t, d.Arr(nil))
+			checker(t, d.Arr(crawlValue), s)
 		}
 	})
 	t.Run("Whitespace", func(t *testing.T) {

--- a/dec_skip_cases_test.go
+++ b/dec_skip_cases_test.go
@@ -161,7 +161,15 @@ func TestDecoder_Skip(t *testing.T) {
 			"nul",                        // invalid
 			"nil",                        // invalid
 			"null",                       // valid
+			`{`,                          // invalid
 			`{}`,                         // valid
+			`{"1}`,                       // invalid
+			`{"1:}`,                      // invalid
+			`{"1,}`,                      // invalid
+			`{"1":}`,                     // invalid
+			`{"\1":}`,                    // invalid
+			`{"1",}`,                     // invalid
+			`{"1":,}`,                    // invalid
 			`{"hello":"world"}`,          // valid
 			`{hello:"world"}`,            // invalid
 			`{"hello:"world"}`,           // invalid

--- a/dec_skip_cases_test.go
+++ b/dec_skip_cases_test.go
@@ -59,12 +59,11 @@ var testStrings = []string{
 	"\"\\uFFFF\"", // valid
 }
 
-var testObj = []string{
+var testObjs = []string{
 	"",                              // invalid
 	"nope",                          // invalid
 	"nul",                           // invalid
 	"nil",                           // invalid
-	"null",                          // valid
 	`{`,                             // invalid
 	`{}`,                            // valid
 	`{"1}`,                          // invalid
@@ -96,6 +95,25 @@ var testObj = []string{
 	`{"foo":`,                       // invalid
 	`{"foo": "bar"`,                 // invalid
 	`{"foo": "bar`,                  // invalid
+}
+
+var testArrs = []string{
+	`[]`,             // valid
+	`[1]`,            // valid
+	`[  1, "hello"]`, // valid
+	`[abc]`,          // invalid
+	`[`,              // invalid
+	`[,`,             // invalid
+	`[[]`,            // invalid
+	"[true,f",        // invalid
+	"[true",          // invalid
+	"[true,",         // invalid
+	"[true]",         // invalid
+	"[true,]",        // invalid
+	"[true,false",    // invalid
+	"[true,false,",   // invalid
+	"[true,false,]",  // invalid
+	"[true,false}",   // invalid
 }
 
 func TestDecoder_Skip(t *testing.T) {
@@ -178,15 +196,8 @@ func TestDecoder_Skip(t *testing.T) {
 	}
 	testCases = append(testCases, numberCase)
 	arrayCase := testCase{
-		ptr: (*[]interface{})(nil),
-		inputs: []string{
-			`[]`,             // valid
-			`[1]`,            // valid
-			`[  1, "hello"]`, // valid
-			`[abc]`,          // invalid
-			`[`,              // invalid
-			`[[]`,            // invalid
-		},
+		ptr:    (*[]interface{})(nil),
+		inputs: append([]string(nil), testArrs...),
 	}
 	for _, c := range numberCase.inputs {
 		arrayCase.inputs = append(arrayCase.inputs, `[`+c+`]`)
@@ -194,7 +205,7 @@ func TestDecoder_Skip(t *testing.T) {
 	testCases = append(testCases, arrayCase)
 	testCases = append(testCases, testCase{
 		ptr:    (*struct{})(nil),
-		inputs: testObj,
+		inputs: testObjs,
 	})
 
 	testDecode := func(iter *Decoder, input string, stdErr error) func(t *testing.T) {

--- a/dec_skip_cases_test.go
+++ b/dec_skip_cases_test.go
@@ -59,6 +59,45 @@ var testStrings = []string{
 	"\"\\uFFFF\"", // valid
 }
 
+var testObj = []string{
+	"",                              // invalid
+	"nope",                          // invalid
+	"nul",                           // invalid
+	"nil",                           // invalid
+	"null",                          // valid
+	`{`,                             // invalid
+	`{}`,                            // valid
+	`{"1}`,                          // invalid
+	`{"1:}`,                         // invalid
+	`{"1,}`,                         // invalid
+	`{"1":}`,                        // invalid
+	`{"\1":}`,                       // invalid
+	`{"1",}`,                        // invalid
+	`{"1":,}`,                       // invalid
+	`{"hello":"world"}`,             // valid
+	`{hello:"world"}`,               // invalid
+	`{"hello:"world"}`,              // invalid
+	`{"hello","world"}`,             // invalid
+	`{"hello":{}`,                   // invalid
+	`{"hello":{}}`,                  // valid
+	`{"hello":{}}}`,                 // invalid
+	`{"hello":  {  "hello": 1}}`,    // valid
+	`{abc}`,                         // invalid
+	`invalid`,                       // invalid
+	`{"foo"`,                        // invalid
+	`{"foo"bar`,                     // invalid
+	`{"foo": "bar",`,                // invalid
+	`{"foo": "bar", true`,           // invalid
+	`{"foo": "bar", "bar":`,         // invalid
+	`{"foo": "bar", "bar":t`,        // invalid
+	`{"foo": "bar", "bar":true`,     // invalid
+	`{"foo": "bar", "bar"false`,     // invalid
+	`{"foo": "bar", "bar": "bar"""`, // invalid
+	`{"foo":`,                       // invalid
+	`{"foo": "bar"`,                 // invalid
+	`{"foo": "bar`,                  // invalid
+}
+
 func TestDecoder_Skip(t *testing.T) {
 	type testCase struct {
 		ptr    interface{}
@@ -154,47 +193,8 @@ func TestDecoder_Skip(t *testing.T) {
 	}
 	testCases = append(testCases, arrayCase)
 	testCases = append(testCases, testCase{
-		ptr: (*struct{})(nil),
-		inputs: []string{
-			"",                           // invalid
-			"nope",                       // invalid
-			"nul",                        // invalid
-			"nil",                        // invalid
-			"null",                       // valid
-			`{`,                          // invalid
-			`{}`,                         // valid
-			`{"1}`,                       // invalid
-			`{"1:}`,                      // invalid
-			`{"1,}`,                      // invalid
-			`{"1":}`,                     // invalid
-			`{"\1":}`,                    // invalid
-			`{"1",}`,                     // invalid
-			`{"1":,}`,                    // invalid
-			`{"hello":"world"}`,          // valid
-			`{hello:"world"}`,            // invalid
-			`{"hello:"world"}`,           // invalid
-			`{"hello","world"}`,          // invalid
-			`{"hello":{}`,                // invalid
-			`{"hello":{}}`,               // valid
-			`{"hello":{}}}`,              // invalid
-			`{"hello":  {  "hello": 1}}`, // valid
-			`{abc}`,                      // invalid
-			`{"logo": null,
-            "name": "Festival Présences 2014 \"Paris Berlin\"",
-            "subTopicIds": [
-                337184288,
-                337184283,
-                337184275
-            ],
-            "subjectCode": null,
-            "subtitle": null,
-            "topicIds": [
-                324846099,
-                107888604,
-                324846100
-            ]
-        }`, // valid
-		},
+		ptr:    (*struct{})(nil),
+		inputs: testObj,
 	})
 
 	testDecode := func(iter *Decoder, input string, stdErr error) func(t *testing.T) {

--- a/dec_str.go
+++ b/dec_str.go
@@ -22,15 +22,11 @@ func (d *Decoder) StrAppend(b []byte) ([]byte, error) {
 }
 
 type value struct {
-	buf    []byte
-	raw    bool // false forces buf reuse
-	ignore bool
+	buf []byte
+	raw bool // false forces buf reuse
 }
 
 func (v value) rune(r rune) value {
-	if v.ignore {
-		return v
-	}
 	return value{
 		buf: appendRune(v.buf, r),
 		raw: v.raw,
@@ -38,9 +34,6 @@ func (v value) rune(r rune) value {
 }
 
 func (v value) byte(b byte) value {
-	if v.ignore {
-		return v
-	}
 	return value{
 		buf: append(v.buf, b),
 		raw: v.raw,
@@ -72,10 +65,6 @@ func (d *Decoder) str(v value) (value, error) {
 		}
 		if c == '"' {
 			// End of string in fast path.
-			if v.ignore {
-				d.head += i + 1
-				return value{}, nil
-			}
 			str := buf[:i]
 			d.head += i + 1
 			if v.raw {


### PR DESCRIPTION
```
name                        old time/op    new time/op    delta
Valid/canada.json-12          3.96ms ± 3%    3.28ms ± 4%  -17.01%  (p=0.000 n=10+15)
Valid/citm_catalog.json-12    1.99ms ± 2%    1.61ms ± 2%  -19.39%  (p=0.000 n=10+14)
Valid/floats.json-12          2.89µs ± 1%    2.58µs ± 1%  -10.57%  (p=0.000 n=10+15)
Valid/large.json-12           55.2µs ± 2%    39.2µs ± 4%  -29.07%  (p=0.000 n=10+15)
Valid/medium.json-12          3.72µs ± 1%    3.10µs ± 3%  -16.82%  (p=0.000 n=10+14)
Valid/otel_ex_1.json-12        719ns ± 5%     567ns ± 4%  -21.11%  (p=0.000 n=10+15)
Valid/small.json-12            396ns ± 2%     295ns ± 2%  -25.38%  (p=0.000 n=10+15)
Valid/twitter.json-12         1.08ms ± 3%    0.78ms ± 2%  -27.86%  (p=0.000 n=10+15)

name                        old speed      new speed      delta
Valid/canada.json-12         569MB/s ± 3%   686MB/s ± 4%  +20.52%  (p=0.000 n=10+15)
Valid/citm_catalog.json-12   892MB/s ± 2%  1107MB/s ± 2%  +24.06%  (p=0.000 n=10+14)
Valid/floats.json-12         807MB/s ± 1%   902MB/s ± 1%  +11.81%  (p=0.000 n=10+15)
Valid/large.json-12          509MB/s ± 2%   718MB/s ± 4%  +41.02%  (p=0.000 n=10+15)
Valid/medium.json-12         703MB/s ± 1%   845MB/s ± 3%  +20.24%  (p=0.000 n=10+14)
Valid/otel_ex_1.json-12      722MB/s ± 6%   914MB/s ± 4%  +26.67%  (p=0.000 n=10+15)
Valid/small.json-12          508MB/s ± 2%   681MB/s ± 2%  +34.00%  (p=0.000 n=10+15)
Valid/twitter.json-12        597MB/s ± 3%   828MB/s ± 2%  +38.62%  (p=0.000 n=10+15)
```