### PR TITLE
test: use integers.json file to benchmark integer decoder

### DIFF
--- a/dec_int.go
+++ b/dec_int.go
@@ -8,13 +8,14 @@ import (
 	"github.com/go-faster/errors"
 )
 
-var intDigits []int8
+var intDigits [256]int8
 
-const uint32SafeToMultiply10 = uint32(0xffffffff)/10 - 1
-const uint64SafeToMultiple10 = uint64(0xffffffffffffffff)/10 - 1
+const (
+	uint32SafeToMultiply10 = uint32(0xffffffff)/10 - 1
+	uint64SafeToMultiple10 = uint64(0xffffffffffffffff)/10 - 1
+)
 
 func init() {
-	intDigits = make([]int8, 256)
 	for i := 0; i < len(intDigits); i++ {
 		intDigits[i] = invalidCharForNumber
 	}

--- a/dec_int_test.go
+++ b/dec_int_test.go
@@ -78,7 +78,7 @@ func TestDecoder_Int(t *testing.T) {
 		return &Decoder{
 			buf:    []byte{'1', '2'},
 			tail:   2,
-			reader: errReader{},
+			reader: r,
 		}
 	}
 	t.Run("32", func(t *testing.T) {

--- a/dec_int_test.go
+++ b/dec_int_test.go
@@ -7,28 +7,50 @@ import (
 )
 
 func BenchmarkDecoder_Int(b *testing.B) {
-	data := []byte(`69315063`)
-	d := GetDecoder()
-	for i := 0; i < b.N; i++ {
-		d.ResetBytes(data)
-		if _, err := d.Int(); err != nil {
-			b.Fatal(err)
-		}
-	}
+	runTestdataFile("integers.json", b.Fatal, func(name string, data []byte) {
+		b.Run(name, func(b *testing.B) {
+			d := GetDecoder()
+			cb := func(d *Decoder) error {
+				_, err := d.Int()
+				return err
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				d.ResetBytes(data)
+
+				if err := d.Arr(cb); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	})
 }
 
 func BenchmarkDecoder_Uint(b *testing.B) {
-	data := []byte(`69315063`)
-	d := GetDecoder()
-	for i := 0; i < b.N; i++ {
-		d.ResetBytes(data)
-		if _, err := d.UInt(); err != nil {
-			b.Fatal(err)
-		}
-	}
+	runTestdataFile("integers.json", b.Fatal, func(name string, data []byte) {
+		b.Run(name, func(b *testing.B) {
+			d := GetDecoder()
+			cb := func(d *Decoder) error {
+				_, err := d.UInt()
+				return err
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				d.ResetBytes(data)
+
+				if err := d.Arr(cb); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	})
 }
 
-func TestDecoder_int_sizes(t *testing.T) {
+func TestDecoderIntSizes(t *testing.T) {
 	data := []byte(`69315063`)
 	d := GetDecoder()
 	for _, size := range []int{32, 64} {
@@ -39,7 +61,7 @@ func TestDecoder_int_sizes(t *testing.T) {
 	}
 }
 
-func TestDecoder_uint_sizes(t *testing.T) {
+func TestDecoderUintSizes(t *testing.T) {
 	data := []byte(`69315063`)
 	d := GetDecoder()
 	for _, size := range []int{32, 64} {

--- a/enc_test.go
+++ b/enc_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncoder_byte_should_grow_buffer(t *testing.T) {
+func TestEncoderByteShouldGrowBuffer(t *testing.T) {
 	should := require.New(t)
 	e := GetEncoder()
 	e.byte('1')
@@ -41,14 +41,14 @@ func TestEncoder(t *testing.T) {
 	})
 }
 
-func TestEncoder_Raw_should_grow_buffer(t *testing.T) {
+func TestEncoderRawShouldGrowBuffer(t *testing.T) {
 	should := require.New(t)
 	e := GetEncoder()
 	e.RawStr("123")
 	should.Equal("123", string(e.Bytes()))
 }
 
-func TestEncoder_Str_should_grow_buffer(t *testing.T) {
+func TestEncoderStrShouldGrowBuffer(t *testing.T) {
 	should := require.New(t)
 	e := GetEncoder()
 	e.Str("123")

--- a/int_test.go
+++ b/int_test.go
@@ -1,11 +1,11 @@
 package jx
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"math"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,26 +73,56 @@ func TestDecoderIntNumbers(t *testing.T) {
 }
 
 func TestReadInt32(t *testing.T) {
-	inputs := []string{`1`, `12`, `123`, `1234`, `12345`, `123456`, `2147483647`, `-2147483648`}
-	for _, input := range inputs {
-		t.Run(input, func(t *testing.T) {
+	inputs := []string{
+		`-12`,
+		`-1`,
+		`0`,
+		`1`,
+		`12`,
+		`123`,
+		`1234`,
+		`12345`,
+		`123456`,
+		`1234567`,
+		`12345678`,
+		`123456789`,
+		`1234567890`,
+		`2147483647`,
+		`-2147483648`,
+	}
+	for i, input := range inputs {
+		input := input
+		t.Run(fmt.Sprintf("Test%d", i+1), createTestCase(input, func(t *testing.T, d *Decoder) error {
 			should := require.New(t)
-			iter := DecodeStr(input)
 			expected, err := strconv.ParseInt(input, 10, 32)
 			should.NoError(err)
-			v, err := iter.Int32()
+			v, err := d.Int32()
 			should.NoError(err)
 			should.Equal(int32(expected), v)
-		})
-		t.Run(input, func(t *testing.T) {
+			return nil
+		}))
+	}
+
+	{
+		input := "[" + strings.Join(inputs, ",") + "]"
+		t.Run("Array", createTestCase(input, func(t *testing.T, d *Decoder) error {
 			should := require.New(t)
-			iter := Decode(bytes.NewBufferString(input), 2)
-			expected, err := strconv.ParseInt(input, 10, 32)
-			should.NoError(err)
-			v, err := iter.Int32()
-			should.NoError(err)
-			should.Equal(int32(expected), v)
-		})
+			i := 0
+
+			return d.Arr(func(d *Decoder) error {
+				expected, err := strconv.ParseInt(inputs[i], 10, 32)
+				should.NoError(err)
+
+				v, err := d.Int32()
+				if err != nil {
+					return err
+				}
+				should.Equal(int32(expected), v)
+
+				i++
+				return nil
+			})
+		}))
 	}
 }
 
@@ -175,26 +205,57 @@ func TestReadInt64Overflow(t *testing.T) {
 }
 
 func TestReadInt64(t *testing.T) {
-	inputs := []string{`1`, `12`, `123`, `1234`, `12345`, `123456`, `9223372036854775807`, `-9223372036854775808`}
-	for _, input := range inputs {
-		t.Run(input, func(t *testing.T) {
+	inputs := []string{
+		`-12`,
+		`-1`,
+		`0`,
+		`1`,
+		`12`,
+		`123`,
+		`1234`,
+		`12345`,
+		`123456`,
+		`1234567`,
+		`12345678`,
+		`123456789`,
+		`1234567890`,
+		`12345678901`,
+		`9223372036854775807`,
+		`-9223372036854775808`,
+	}
+	for i, input := range inputs {
+		input := input
+		t.Run(fmt.Sprintf("Test%d", i+1), createTestCase(input, func(t *testing.T, d *Decoder) error {
 			should := require.New(t)
-			iter := DecodeStr(input)
 			expected, err := strconv.ParseInt(input, 10, 64)
 			should.NoError(err)
-			v, err := iter.Int64()
+			v, err := d.Int64()
 			should.NoError(err)
 			should.Equal(expected, v)
-		})
-		t.Run(input, func(t *testing.T) {
+			return nil
+		}))
+	}
+
+	{
+		input := "[" + strings.Join(inputs, ",") + "]"
+		t.Run("Array", createTestCase(input, func(t *testing.T, d *Decoder) error {
 			should := require.New(t)
-			iter := Decode(bytes.NewBufferString(input), 2)
-			expected, err := strconv.ParseInt(input, 10, 64)
-			should.NoError(err)
-			v, err := iter.Int64()
-			should.NoError(err)
-			should.Equal(expected, v)
-		})
+			i := 0
+
+			return d.Arr(func(d *Decoder) error {
+				expected, err := strconv.ParseInt(inputs[i], 10, 64)
+				should.NoError(err)
+
+				v, err := d.Int64()
+				if err != nil {
+					return err
+				}
+				should.Equal(expected, v)
+
+				i++
+				return nil
+			})
+		}))
 	}
 }
 


### PR DESCRIPTION
```
name                         old time/op    new time/op    delta
Decoder_Int/integers.json-4    3.61µs ± 2%    3.26µs ± 2%  -9.82%  (p=0.000 n=14+15)

name                         old alloc/op   new alloc/op   delta
Decoder_Int/integers.json-4     0.00B          0.00B         ~     (all equal)

name                         old allocs/op  new allocs/op  delta
Decoder_Int/integers.json-4      0.00           0.00         ~     (all equal)
```
