### PR TITLE
fix: parse Num correctly

### DIFF
--- a/dec_num.go
+++ b/dec_num.go
@@ -56,13 +56,13 @@ func (d *Decoder) num(v Num, forceAppend bool) (Num, error) {
 				return nil, err
 			}
 			return Num(raw), nil
-		} else {
-			raw, err := d.Raw()
-			if err != nil {
-				return nil, err
-			}
-			return Num(raw), nil
 		}
+
+		raw, err := d.Raw()
+		if err != nil {
+			return nil, err
+		}
+		return Num(raw), nil
 	default:
 		return v, errors.Errorf("unexpected %s", d.Next())
 	}

--- a/dec_num.go
+++ b/dec_num.go
@@ -18,58 +18,52 @@ func (d *Decoder) NumAppend(v Num) (Num, error) {
 
 // num decodes number.
 func (d *Decoder) num(v Num, forceAppend bool) (Num, error) {
-	var str bool
 	switch d.Next() {
 	case String:
-		str = true
+		str, err := d.StrBytes()
+		if err != nil {
+			return Num{}, errors.Wrap(err, "str")
+		}
+
+		d := Decoder{}
+		d.ResetBytes(str)
+
+		// Validate number.
+		c, err := d.next()
+		if err != nil {
+			return Num{}, err
+		}
+		switch c {
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-':
+			d.unread()
+
+			if err := d.skipNumber(); err != nil {
+				return Num{}, errors.Wrap(err, "skip number")
+			}
+		default:
+			return nil, badToken(c)
+		}
+
+		v = append(v, '"')
+		v = append(v, str...)
+		v = append(v, '"')
+
+		return v, nil
 	case Number: // float or integer
+		if forceAppend {
+			raw, err := d.RawAppend(Raw(v))
+			if err != nil {
+				return nil, err
+			}
+			return Num(raw), nil
+		} else {
+			raw, err := d.Raw()
+			if err != nil {
+				return nil, err
+			}
+			return Num(raw), nil
+		}
 	default:
 		return v, errors.Errorf("unexpected %s", d.Next())
 	}
-	if d.reader == nil && !forceAppend {
-		// Can use underlying buffer directly.
-		start := d.head
-		d.head++
-		d.number()
-		if str {
-			if err := d.consume('"'); err != nil {
-				return nil, errors.Wrap(err, "end of string")
-			}
-		}
-		v = d.buf[start:d.head]
-	} else {
-		if str {
-			d.head++ // '"'
-			v = append(v, '"')
-		}
-		buf, err := d.numberAppend(v)
-		if err != nil {
-			return v, errors.Wrap(err, "decode")
-		}
-		if str {
-			if err := d.consume('"'); err != nil {
-				return nil, errors.Wrap(err, "end of string")
-			}
-			buf = append(buf, '"')
-		}
-		v = buf
-	}
-
-	var dot bool
-	for _, c := range v {
-		if c != '.' {
-			continue
-		}
-		if dot {
-			return v, errors.New("multiple dots in number")
-		}
-		dot = true
-	}
-
-	// TODO(ernado): Additional validity checks
-	// Current invariants:
-	// 1) Zero or one dot
-	// 2) Only: +, -, ., e, E, 0-9
-
-	return v, nil
 }

--- a/dec_num_test.go
+++ b/dec_num_test.go
@@ -1,13 +1,39 @@
 package jx
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestDecoder_Num(t *testing.T) {
+func testDecoderNum(t *testing.T, num func(*Decoder) (Num, error)) {
+	t.Run("Cases", func(t *testing.T) {
+		runTestCases(t, testNumbers, func(t *testing.T, d *Decoder) error {
+			if _, err := num(d); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != nil {
+				if err != io.EOF && err != io.ErrUnexpectedEOF {
+					return err
+				}
+			}
+			return nil
+		})
+	})
+
+	t.Run("StrEscape", func(t *testing.T) {
+		a := require.New(t)
+		for _, s := range []string{
+			`"\u0030"`,                   // hex 30 = dec 48 = '0'
+			`"\u002d\u0031\u0030\u0030"`, // "-100", but escaped
+		} {
+			_, err := num(DecodeStr(s))
+			a.NoErrorf(err, "input: %q", s)
+		}
+	})
 	t.Run("Positive", func(t *testing.T) {
+		a := require.New(t)
 		for _, s := range []string{
 			`100`,
 			`100.0`,
@@ -16,28 +42,33 @@ func TestDecoder_Num(t *testing.T) {
 			`"-100"`,
 			`"-100.0"`,
 		} {
-			v, err := DecodeStr(s).Num()
-			require.NoError(t, err)
-			require.Equal(t, s, v.String())
-
-			v, err = DecodeStr(s).NumAppend(nil)
-			require.NoError(t, err)
-			require.Equal(t, s, v.String())
+			v, err := num(DecodeStr(s))
+			a.NoErrorf(err, "input: %q", s)
+			a.Equalf(s, v.String(), "input: %q", s)
 		}
 	})
 	t.Run("Negative", func(t *testing.T) {
+		a := require.New(t)
 		for _, s := range []string{
 			`1.00.0`,
 			`"-100`,
+			`""`,
 			`"-100.0.0"`,
 			"false",
 			`"false"`,
 		} {
-			_, err := DecodeStr(s).Num()
-			require.Error(t, err, s)
-
-			_, err = DecodeStr(s).NumAppend(nil)
-			require.Error(t, err, s)
+			_, err := num(DecodeStr(s))
+			a.Errorf(err, "input: %q", s)
 		}
+	})
+}
+
+func TestDecoder_Num(t *testing.T) {
+	testDecoderNum(t, (*Decoder).Num)
+}
+
+func TestDecoder_NumAppend(t *testing.T) {
+	testDecoderNum(t, func(d *Decoder) (Num, error) {
+		return d.NumAppend(nil)
 	})
 }

--- a/dec_str.go
+++ b/dec_str.go
@@ -126,7 +126,7 @@ readTok:
 		// Skip string + last quote.
 		d.head += i + 1
 		if v.raw {
-			return value{buf: str}, nil
+			return value{buf: str, raw: true}, nil
 		}
 		return value{buf: append(v.buf, str...)}, nil
 	case c == '\\':

--- a/dec_test.go
+++ b/dec_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testBufferReader runs the given test function with various decoding modes (buffered, streaming, etc.).
 func testBufferReader(input string, cb func(t *testing.T, d *Decoder)) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Run("Buffer", func(t *testing.T) {

--- a/num_test.go
+++ b/num_test.go
@@ -2,6 +2,7 @@ package jx
 
 import (
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,19 @@ func TestEncoder_Num(t *testing.T) {
 }
 
 func TestNum(t *testing.T) {
+	t.Run("Cases", func(t *testing.T) {
+		runTestCases(t, testNumbers, func(t *testing.T, d *Decoder) error {
+			if _, err := d.Num(); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != nil {
+				if err != io.EOF && err != io.ErrUnexpectedEOF {
+					return err
+				}
+			}
+			return nil
+		})
+	})
 	t.Run("Format", func(t *testing.T) {
 		assert.Equal(t, `-12`, fmt.Sprintf("%d", Num(`"-12.0"`)))
 		assert.Equal(t, `-12.000000`, fmt.Sprintf("%f", Num(`"-12.0"`)))

--- a/num_test.go
+++ b/num_test.go
@@ -2,7 +2,6 @@ package jx
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -179,59 +178,6 @@ func TestNum(t *testing.T) {
 			assert.Equal(t, s, v.String())
 		})
 	})
-}
-
-func BenchmarkDecoder_Num(b *testing.B) {
-	for _, bt := range []struct {
-		name  string
-		input string
-	}{
-		{`Number`, `1234567890421`},
-		{`String`, `"1234567890421"`},
-	} {
-		bt := bt
-		b.Run(bt.name, func(b *testing.B) {
-			b.Run("Buffer", func(b *testing.B) {
-				var (
-					input = []byte(bt.input)
-					d     = DecodeBytes(input)
-					err   error
-				)
-
-				b.ReportAllocs()
-				b.ResetTimer()
-
-				for i := 0; i < b.N; i++ {
-					d.ResetBytes(input)
-					_, err = d.Num()
-				}
-
-				if err != nil {
-					b.Fatal(err)
-				}
-			})
-			b.Run("Reader", func(b *testing.B) {
-				var (
-					r   = strings.NewReader(bt.input)
-					d   = Decode(r, 512)
-					err error
-				)
-
-				b.ReportAllocs()
-				b.ResetTimer()
-
-				for i := 0; i < b.N; i++ {
-					r.Reset(bt.input)
-					d.Reset(r)
-					_, err = d.Num()
-				}
-
-				if err != nil {
-					b.Fatal(err)
-				}
-			})
-		})
-	}
 }
 
 func BenchmarkNum(b *testing.B) {

--- a/num_test.go
+++ b/num_test.go
@@ -3,6 +3,7 @@ package jx
 import (
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -192,6 +193,59 @@ func TestNum(t *testing.T) {
 			assert.Equal(t, s, v.String())
 		})
 	})
+}
+
+func BenchmarkDecoder_Num(b *testing.B) {
+	for _, bt := range []struct {
+		name  string
+		input string
+	}{
+		{`Number`, `1234567890421`},
+		{`String`, `"1234567890421"`},
+	} {
+		bt := bt
+		b.Run(bt.name, func(b *testing.B) {
+			b.Run("Buffer", func(b *testing.B) {
+				var (
+					input = []byte(bt.input)
+					d     = DecodeBytes(input)
+					err   error
+				)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					d.ResetBytes(input)
+					_, err = d.Num()
+				}
+
+				if err != nil {
+					b.Fatal(err)
+				}
+			})
+			b.Run("Reader", func(b *testing.B) {
+				var (
+					r   = strings.NewReader(bt.input)
+					d   = Decode(r, 512)
+					err error
+				)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					r.Reset(bt.input)
+					d.Reset(r)
+					_, err = d.Num()
+				}
+
+				if err != nil {
+					b.Fatal(err)
+				}
+			})
+		})
+	}
 }
 
 func BenchmarkNum(b *testing.B) {

--- a/num_test.go
+++ b/num_test.go
@@ -2,7 +2,6 @@ package jx
 
 import (
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 
@@ -24,19 +23,6 @@ func TestEncoder_Num(t *testing.T) {
 }
 
 func TestNum(t *testing.T) {
-	t.Run("Cases", func(t *testing.T) {
-		runTestCases(t, testNumbers, func(t *testing.T, d *Decoder) error {
-			if _, err := d.Num(); err != nil {
-				return err
-			}
-			if err := d.Skip(); err != nil {
-				if err != io.EOF && err != io.ErrUnexpectedEOF {
-					return err
-				}
-			}
-			return nil
-		})
-	})
 	t.Run("Format", func(t *testing.T) {
 		assert.Equal(t, `-12`, fmt.Sprintf("%d", Num(`"-12.0"`)))
 		assert.Equal(t, `-12.000000`, fmt.Sprintf("%f", Num(`"-12.0"`)))


### PR DESCRIPTION
```
name                         old time/op    new time/op    delta
Decoder_Num/Number/Buffer-4    36.1ns ± 2%    41.4ns ± 2%   +14.55%  (p=0.000 n=15+15)
Decoder_Num/Number/Reader-4     112ns ± 4%     181ns ± 2%   +62.01%  (p=0.000 n=14+15)
Decoder_Num/String/Buffer-4    43.7ns ± 5%    55.1ns ± 1%   +26.15%  (p=0.000 n=14+13)
Decoder_Num/String/Reader-4     142ns ± 1%      75ns ± 6%   -47.13%  (p=0.000 n=13+13)

name                         old alloc/op   new alloc/op   delta
Decoder_Num/Number/Buffer-4     0.00B          0.00B           ~     (all equal)
Decoder_Num/Number/Reader-4     16.0B ± 0%     64.0B ± 0%  +300.00%  (p=0.000 n=15+15)
Decoder_Num/String/Buffer-4     0.00B          0.00B           ~     (all equal)
Decoder_Num/String/Reader-4     24.0B ± 0%      0.0B       -100.00%  (p=0.000 n=15+15)

name                         old allocs/op  new allocs/op  delta
Decoder_Num/Number/Buffer-4      0.00           0.00           ~     (all equal)
Decoder_Num/Number/Reader-4      1.00 ± 0%      2.00 ± 0%  +100.00%  (p=0.000 n=15+15)
Decoder_Num/String/Buffer-4      0.00           0.00           ~     (all equal)
Decoder_Num/String/Reader-4      2.00 ± 0%      0.00       -100.00%  (p=0.000 n=15+15)
```
