### PR TITLE
refactor: handle `bufSize` properly

### DIFF
--- a/.github/workflows/x.yml
+++ b/.github/workflows/x.yml
@@ -15,6 +15,8 @@ jobs:
     uses: go-faster/x/.github/workflows/cover.yml@main
   lint:
     uses: go-faster/x/.github/workflows/lint.yml@main
+    with:
+      golangci-lint: v1.50.1
   commit:
     uses: go-faster/x/.github/workflows/commit.yml@main
   nancy:

--- a/enc_bench_test.go
+++ b/enc_bench_test.go
@@ -130,7 +130,7 @@ func BenchmarkEncodeFloats(b *testing.B) {
 	b.Run("Stream", func(b *testing.B) {
 		b.SetBytes(size)
 		b.RunParallel(func(pb *testing.PB) {
-			enc := NewStreamingEncoder(io.Discard, 512)
+			enc := NewStreamingEncoder(io.Discard, -1)
 			for pb.Next() {
 				enc.ResetWriter(io.Discard)
 				encodeFloats(enc, arr)

--- a/enc_stream.go
+++ b/enc_stream.go
@@ -3,14 +3,17 @@ package jx
 import "io"
 
 const (
-	minEncoderBufSize = 32
 	encoderBufSize    = 512
+	minEncoderBufSize = 32
 )
 
 // NewStreamingEncoder creates new streaming encoder.
 func NewStreamingEncoder(w io.Writer, bufSize int) *Encoder {
-	if bufSize < minEncoderBufSize {
+	switch {
+	case bufSize < 0:
 		bufSize = encoderBufSize
+	case bufSize < minEncoderBufSize:
+		bufSize = minEncoderBufSize
 	}
 	return &Encoder{
 		w: Writer{


### PR DESCRIPTION
Set buffer size to default if it is below zero.
If it is below minimum, set to minimum.
