### PR TITLE
 allow Write during streaming mode. add Flush function

### DIFF
--- a/w.go
+++ b/w.go
@@ -17,7 +17,9 @@ type Writer struct {
 func (w *Writer) Write(p []byte) (n int, err error) {
 	if w.stream != nil {
 		if len(w.Buf) > 0 {
-			w.Flush()
+			if w.Flush() {
+				return 0, w.stream.writeErr
+			}
 		}
 		return w.stream.writer.Write(p)
 	}

--- a/w.go
+++ b/w.go
@@ -68,7 +68,7 @@ func (w *Writer) Grow(n int) {
 	w.Buf = buf.Bytes()
 }
 
-// flush flushes the stream
+// Flush flushes the stream. It does nothing if not in streaming mode
 func (w *Writer) Flush() (fail bool) {
 	if w.stream != nil {
 		w.Buf, fail = w.stream.flush(w.Buf)

--- a/w_stream.go
+++ b/w_stream.go
@@ -94,7 +94,6 @@ func writeStreamByteseqSlow[S byteseq.Byteseq](w *Writer, s S) bool {
 		if fail {
 			return true
 		}
-
 		n := copy(w.Buf[len(w.Buf):cap(w.Buf)], s)
 		s = s[n:]
 		w.Buf = w.Buf[:len(w.Buf)+n]


### PR DESCRIPTION
https://github.com/go-faster/jx/issues/84

very open to changing this api, the need is to just to be able to encode arbitrary bytes into the middle of the stream.